### PR TITLE
Require latest version of cljsjs/jquery-daterange-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [Hoplon][hoplon] wrapper for the [jQuery date range picker plugin][1].
 
 [](dependency)
 ```clojure
-[hoplon/jquery-daterange-picker "0.0.5-0"] ;; latest release
+[hoplon/jquery-daterange-picker "0.0.8-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :source-paths #{"src"}
   :dependencies '[[adzerk/bootlaces               "0.1.12"        :scope "test"]
-                  [cljsjs/jquery-daterange-picker "0.0.5-2"]
+                  [cljsjs/jquery-daterange-picker "0.0.8-0"]
                   [hoplon                         "6.0.0-alpha10"]
                   [hoplon/boot-hoplon             "0.1.10"]
                   [org.clojure/clojure            "1.7.0"]])
@@ -10,7 +10,7 @@
   '[adzerk.bootlaces :refer :all]
   '[hoplon.boot-hoplon :refer [hoplon]])
 
-(def +version+ "0.0.5-0")
+(def +version+ "0.0.8-0")
 (bootlaces! +version+)
 
 (task-options!


### PR DESCRIPTION
We are requiring 0.0.8 release of jquery-daterange-picker to keep things updated.
The 0.0.8 release resolves some bugs and add more functionality.

Bug fixes:
- Auto close
- Hover highlight over days etc.
