### PR TITLE
Fixed `format.replace is not a function` console error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [Hoplon][hoplon] wrapper for the [jQuery date range picker plugin][1].
 
 [](dependency)
 ```clojure
-[hoplon/jquery-daterange-picker "0.0.8-0"] ;; latest release
+[hoplon/jquery-daterange-picker "0.0.8-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -10,7 +10,7 @@
   '[adzerk.bootlaces :refer :all]
   '[hoplon.boot-hoplon :refer [hoplon]])
 
-(def +version+ "0.0.8-0")
+(def +version+ "0.0.8-1")
 (bootlaces! +version+)
 
 (task-options!

--- a/src/hoplon/jquery/daterangepicker.cljs.hl
+++ b/src/hoplon/jquery/daterangepicker.cljs.hl
@@ -36,7 +36,7 @@
 (defelem daterange
   [{:keys [state opts] :as attr} _]
   (cell-let [{:keys [format] :as opts} (cell= (merge {:format "YYYY-MM-DD"} opts))
-             format #(.format (js/moment %) format)]
+             format #(.format (js/moment %) @format)]
     (with-let [elem (input (dissoc attr :state :opts))]
       (elem
         :click #(do (reset! open-picker elem) false)


### PR DESCRIPTION
`format` passed to moment.js#format has been a cell and raised `format.replace is not a function` error in the console.